### PR TITLE
Update Course4Resources.yaml

### DIFF
--- a/Course4Resources.yaml
+++ b/Course4Resources.yaml
@@ -24,7 +24,7 @@ Resources:
     EC2Instance:
         Type: "AWS::EC2::Instance"
         Properties:
-            ImageId: "ami-048f6ed62451373d9"
+            ImageId: "ami-079db87dc4c10ac91"
             InstanceType: "t2.micro"
             KeyName: "vockey"
             AvailabilityZone: "us-east-1a"
@@ -52,7 +52,7 @@ Resources:
     EC2Instance2:
         Type: "AWS::EC2::Instance"
         Properties:
-            ImageId: "ami-048f6ed62451373d9"
+            ImageId: "ami-079db87dc4c10ac91"
             InstanceType: "t2.micro"
             KeyName: "vockey"
             AvailabilityZone: "us-east-1b"


### PR DESCRIPTION
Code was failing due to invalid AMI as AWS has updated it Linux images. So I changed this   ImageId: "ami-048f6ed62451373d9" to ImageId: "ami-079db87dc4c10ac91" to fix the template rollback errors